### PR TITLE
Use jq instead of Ruby

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -29,7 +29,7 @@ fi
 cache_get_url=$(curl -s https://api.heroku.com/apps/$SHARED_BUILD_CACHE_APP_NAME/build-metadata \
   -H "Accept: application/vnd.heroku+json; version=3.build-metadata" \
   -H "Authorization: Bearer $HEROKU_API_KEY" \
-  | jq .cache_get_url)
+  | jq -r .cache_get_url)
 
 echo "Restoring shared build cache from app [$SHARED_BUILD_CACHE_APP_NAME]..."
 

--- a/bin/compile
+++ b/bin/compile
@@ -29,7 +29,7 @@ fi
 cache_get_url=$(curl -s https://api.heroku.com/apps/$SHARED_BUILD_CACHE_APP_NAME/build-metadata \
   -H "Accept: application/vnd.heroku+json; version=3.build-metadata" \
   -H "Authorization: Bearer $HEROKU_API_KEY" \
-  | ruby -e "require 'json'; print JSON[STDIN.read]['cache_get_url']")
+  | jq .cache_get_url)
 
 echo "Restoring shared build cache from app [$SHARED_BUILD_CACHE_APP_NAME]..."
 


### PR DESCRIPTION
This buildpack depended on Ruby being available, but in Heroku-22 Ruby is no longer installed by default, so we use `jq` instead. The default packages can be viewed at https://devcenter.heroku.com/articles/stack-packages and it shows no more Ruby packages in Heroku-22.

After the fact I noticed Kajabi/heroku-buildpack-shared-build-cache#2 which tweaked the `jq` invocation, and I've applied that here as well